### PR TITLE
Feature/flink 36536 bump commons text from 1.10.0 to 1.12.0

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -15,7 +15,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-math3:3.6.1
-- org.apache.commons:commons-text:1.10.0
+- org.apache.commons:commons-text:1.12.0
 - org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:3.4

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -13,7 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.15.1
 - org.apache.commons:commons-compress:1.26.0
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-math3:3.6.1
 - org.apache.commons:commons-text:1.12.0
 - org.javassist:javassist:3.24.0-GA

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -21,7 +21,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
-- org.apache.commons:commons-text:1.10.0
+- org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -27,7 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
-- org.apache.commons:commons-text:1.10.0
+- org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -26,7 +26,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -39,7 +39,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
-- org.apache.commons:commons-text:1.10.0
+- org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -38,7 +38,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.alluxio:alluxio-shaded-client:2.7.3
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-text:1.12.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -15,7 +15,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.confluent:kafka-schema-registry-client:7.5.3
 - org.apache.avro:avro:1.11.4
 - org.apache.commons:commons-compress:1.26.0
-- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-lang3:3.14.0
 - org.apache.kafka:kafka-clients:7.5.3-ccs
 - org.xerial.snappy:snappy-java:1.1.10.7
 - org.yaml:snakeyaml:2.3

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.12.0</version>
+				<version>3.14.0</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
+				<version>1.12.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Bumped commons-text from 1.10.0 to 1.12.0 to resolve the vulnerability [CVE-2024-47554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554)